### PR TITLE
Adding check for nil map value

### DIFF
--- a/bootstrap/asn_registry_test.go
+++ b/bootstrap/asn_registry_test.go
@@ -7,7 +7,7 @@ package bootstrap
 import (
 	"testing"
 
-	"github.com/openrdap/rdap/test"
+	"github.com/projectdiscovery/rdap/test"
 )
 
 func TestNetRegistryLookupsASN(t *testing.T) {

--- a/bootstrap/client.go
+++ b/bootstrap/client.go
@@ -350,9 +350,7 @@ func (c *Client) Lookup(question *Question) (*Answer, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	answer, err := reg.Lookup(question)
-
 	if answer != nil {
 		c.Verbose(fmt.Sprintf("  bootstrap: Looked up '%s'", answer.Query))
 		if answer.Entry != "" {

--- a/bootstrap/client.go
+++ b/bootstrap/client.go
@@ -14,36 +14,38 @@
 // files.
 //
 // Basic usage:
-//   question := &bootstrap.Question{
-//     RegistryType: bootstrap.DNS,
-//     Query: "example.cz",
-//   }
 //
-//   b := &bootstrap.Client{}
+//	question := &bootstrap.Question{
+//	  RegistryType: bootstrap.DNS,
+//	  Query: "example.cz",
+//	}
 //
-//   var answer *bootstrap.Answer
-//   answer, err := b.Lookup(question)
+//	b := &bootstrap.Client{}
 //
-//   if err == nil {
-//     for _, url := range answer.URLs {
-//       fmt.Println(url)
-//     }
-//   }
+//	var answer *bootstrap.Answer
+//	answer, err := b.Lookup(question)
+//
+//	if err == nil {
+//	  for _, url := range answer.URLs {
+//	    fmt.Println(url)
+//	  }
+//	}
 //
 // Download and list the contents of the DNS Service Registry:
-//   b := &bootstrap.Client{}
 //
-//   // Before you can use a Registry, you need to download it first.
-//   err := b.Download(bootstrap.DNS) // Downloads https://data.iana.org/rdap/dns.json.
+//	b := &bootstrap.Client{}
 //
-//   if err == nil {
-//     var dns *DNSRegistry = b.DNS()
+//	// Before you can use a Registry, you need to download it first.
+//	err := b.Download(bootstrap.DNS) // Downloads https://data.iana.org/rdap/dns.json.
 //
-//     // Print TLDs with RDAP service.
-//     for tld, _ := range dns.File().Entries {
-//       fmt.Println(tld)
-//     }
-//   }
+//	if err == nil {
+//	  var dns *DNSRegistry = b.DNS()
+//
+//	  // Print TLDs with RDAP service.
+//	  for tld, _ := range dns.File().Entries {
+//	    fmt.Println(tld)
+//	  }
+//	}
 //
 // You can configure bootstrap.Client{} with a custom http.Client, base URL
 // (default https://data.iana.org/rdap), and custom cache. bootstrap.Question{}
@@ -68,16 +70,16 @@
 //
 // Disk cache usage:
 //
-//   b := bootstrap.NewClient()
-//   b.Cache = cache.NewDiskCache()
+//	b := bootstrap.NewClient()
+//	b.Cache = cache.NewDiskCache()
 //
-//   dsr := b.DNS()  // Tries to load dns.json from disk cache, doesn't exist yet, so returns nil.
-//   b.Download(bootstrap.DNS) // Downloads dns.json, saves to disk cache.
+//	dsr := b.DNS()  // Tries to load dns.json from disk cache, doesn't exist yet, so returns nil.
+//	b.Download(bootstrap.DNS) // Downloads dns.json, saves to disk cache.
 //
-//   b2 := bootstrap.NewClient()
-//   b2.Cache = cache.NewDiskCache()
+//	b2 := bootstrap.NewClient()
+//	b2.Cache = cache.NewDiskCache()
 //
-//   dsr2 := b.DNS()  // Loads dns.json from disk cache.
+//	dsr2 := b.DNS()  // Loads dns.json from disk cache.
 //
 // This package also implements the experimental Service Provider registry. Due
 // to the experimental nature, no Service Registry file exists on data.iana.org
@@ -91,13 +93,14 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
 
-	"github.com/openrdap/rdap/bootstrap/cache"
+	"github.com/projectdiscovery/rdap/bootstrap/cache"
 )
 
 // A RegistryType represents a bootstrap registry type.
@@ -204,6 +207,15 @@ func (c *Client) DownloadWithContext(ctx context.Context, registry RegistryType)
 
 	return nil
 
+}
+
+// getRegistry checks if we have the proper registry in the internal map
+func (c *Client) getRegistry(registryType RegistryType) (Registry, error) {
+	registry, ok := c.registries[registryType]
+	if ok {
+		return registry, nil
+	}
+	return nil, errors.New("registry not found")
 }
 
 func (c *Client) download(ctx context.Context, registry RegistryType) ([]byte, Registry, error) {
@@ -334,7 +346,12 @@ func (c *Client) Lookup(question *Question) (*Answer, error) {
 		c.Verbose("  bootstrap: Using cached Service Registry file")
 	}
 
-	answer, err := c.registries[registry].Lookup(question)
+	reg, err := c.getRegistry(registry)
+	if err != nil {
+		return nil, err
+	}
+
+	answer, err := reg.Lookup(question)
 
 	if answer != nil {
 		c.Verbose(fmt.Sprintf("  bootstrap: Looked up '%s'", answer.Query))
@@ -363,7 +380,6 @@ func (c *Client) ASN() *ASNRegistry {
 	return s
 }
 
-//
 // DNS returns the current DNS Registry (or nil if the registry file hasn't been Download()ed).
 //
 // This function never initiates a network transfer.

--- a/bootstrap/client_test.go
+++ b/bootstrap/client_test.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/openrdap/rdap/test"
+	"github.com/projectdiscovery/rdap/test"
 )
 
 func TestDownload(t *testing.T) {

--- a/bootstrap/dns_registry_test.go
+++ b/bootstrap/dns_registry_test.go
@@ -7,7 +7,7 @@ package bootstrap
 import (
 	"testing"
 
-	"github.com/openrdap/rdap/test"
+	"github.com/projectdiscovery/rdap/test"
 )
 
 func TestNetRegistryLookupsDNSNested(t *testing.T) {

--- a/bootstrap/file_test.go
+++ b/bootstrap/file_test.go
@@ -7,7 +7,7 @@ package bootstrap
 import (
 	"testing"
 
-	"github.com/openrdap/rdap/test"
+	"github.com/projectdiscovery/rdap/test"
 )
 
 func TestParseValid(t *testing.T) {

--- a/bootstrap/net_registry_test.go
+++ b/bootstrap/net_registry_test.go
@@ -7,7 +7,7 @@ package bootstrap
 import (
 	"testing"
 
-	"github.com/openrdap/rdap/test"
+	"github.com/projectdiscovery/rdap/test"
 )
 
 func TestNetRegistryLookupsIPv4(t *testing.T) {

--- a/bootstrap/service_provider_registry_test.go
+++ b/bootstrap/service_provider_registry_test.go
@@ -7,7 +7,7 @@ package bootstrap
 import (
 	"testing"
 
-	"github.com/openrdap/rdap/test"
+	"github.com/projectdiscovery/rdap/test"
 )
 
 func TestServiceProviderRegistryLookups(t *testing.T) {

--- a/cli.go
+++ b/cli.go
@@ -17,9 +17,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/openrdap/rdap/bootstrap"
-	"github.com/openrdap/rdap/bootstrap/cache"
-	"github.com/openrdap/rdap/sandbox"
+	"github.com/projectdiscovery/rdap/bootstrap"
+	"github.com/projectdiscovery/rdap/bootstrap/cache"
+	"github.com/projectdiscovery/rdap/sandbox"
 
 	"golang.org/x/crypto/pkcs12"
 

--- a/client.go
+++ b/client.go
@@ -108,6 +108,9 @@ func (c *Client) Do(req *Request) (*Response, error) {
 	// Init Verbose callback?
 	if c.Verbose == nil {
 		c.Verbose = func(text string) {}
+		c.Bootstrap.Verbose = func(text string) {}
+	} else {
+		c.Bootstrap.Verbose = c.Verbose
 	}
 
 	c.Verbose("")

--- a/client.go
+++ b/client.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/openrdap/rdap/bootstrap"
+	"github.com/projectdiscovery/rdap/bootstrap"
 )
 
 // Client implements an RDAP client.
@@ -20,54 +20,58 @@ import (
 // This client executes RDAP requests, and returns the responses as Go values.
 //
 // Quick usage:
-//   client := &rdap.Client{}
-//   domain, err := client.QueryDomain("example.cz")
 //
-//   if err == nil {
-//     fmt.Printf("Handle=%s Domain=%s\n", domain.Handle, domain.LDHName)
-//   }
+//	client := &rdap.Client{}
+//	domain, err := client.QueryDomain("example.cz")
+//
+//	if err == nil {
+//	  fmt.Printf("Handle=%s Domain=%s\n", domain.Handle, domain.LDHName)
+//	}
+//
 // The QueryDomain(), QueryAutnum(), and QueryIP() methods all provide full contact information, and timeout after 30s.
 //
 // Normal usage:
-//   // Query example.cz.
-//   req := &rdap.Request{
-//     Type: rdap.DomainRequest,
-//     Query: "example.cz",
-//   }
 //
-//   client := &rdap.Client{}
-//   resp, err := client.Do(req)
+//	// Query example.cz.
+//	req := &rdap.Request{
+//	  Type: rdap.DomainRequest,
+//	  Query: "example.cz",
+//	}
 //
-//   if domain, ok := resp.Object.(*rdap.Domain); ok {
-//     fmt.Printf("Handle=%s Domain=%s\n", domain.Handle, domain.LDHName)
-//   }
+//	client := &rdap.Client{}
+//	resp, err := client.Do(req)
+//
+//	if domain, ok := resp.Object.(*rdap.Domain); ok {
+//	  fmt.Printf("Handle=%s Domain=%s\n", domain.Handle, domain.LDHName)
+//	}
 //
 // Advanced usage:
 //
 // This demonstrates custom FetchRoles, a custom Context, a custom HTTP client,
 // a custom Bootstrapper, and a custom timeout.
-//   // Nameserver query on rdap.nic.cz.
-//   server, _ := url.Parse("https://rdap.nic.cz")
-//   req := &rdap.Request{
-//     Type: rdap.NameserverRequest,
-//     Query: "a.ns.nic.cz",
-//     FetchRoles: []string{"all"},
-//     Timeout: time.Second * 45, // Custom timeout.
 //
-//     Server: server,
-//   }
+//	// Nameserver query on rdap.nic.cz.
+//	server, _ := url.Parse("https://rdap.nic.cz")
+//	req := &rdap.Request{
+//	  Type: rdap.NameserverRequest,
+//	  Query: "a.ns.nic.cz",
+//	  FetchRoles: []string{"all"},
+//	  Timeout: time.Second * 45, // Custom timeout.
 //
-//   req = req.WithContext(ctx) // Custom context (see https://blog.golang.org/context).
+//	  Server: server,
+//	}
 //
-//   client := &rdap.Client{}
-//   client.HTTP = &http.Client{} // Custom HTTP client.
-//   client.Bootstrap = &bootstrap.Client{} // Custom bootstapper.
+//	req = req.WithContext(ctx) // Custom context (see https://blog.golang.org/context).
 //
-//   resp, err := client.Do(req)
+//	client := &rdap.Client{}
+//	client.HTTP = &http.Client{} // Custom HTTP client.
+//	client.Bootstrap = &bootstrap.Client{} // Custom bootstapper.
 //
-//   if ns, ok := resp.Object.(*rdap.Nameserver); ok {
-//     fmt.Printf("Handle=%s Domain=%s\n", ns.Handle, ns.LDHName)
-//   }
+//	resp, err := client.Do(req)
+//
+//	if ns, ok := resp.Object.(*rdap.Nameserver); ok {
+//	  fmt.Printf("Handle=%s Domain=%s\n", ns.Handle, ns.LDHName)
+//	}
 type Client struct {
 	HTTP      *http.Client
 	Bootstrap *bootstrap.Client

--- a/client_test.go
+++ b/client_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/openrdap/rdap/test"
+	"github.com/projectdiscovery/rdap/test"
 )
 
 func verboseFunc() func(text string) {

--- a/cmd/rdap/main.go
+++ b/cmd/rdap/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/openrdap/rdap"
+	"github.com/projectdiscovery/rdap"
 )
 
 func main() {

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/openrdap/rdap/test"
+	"github.com/projectdiscovery/rdap/test"
 )
 
 func TestDecodeEmpty(t *testing.T) {

--- a/example_test.go
+++ b/example_test.go
@@ -7,7 +7,7 @@ package rdap_test
 import (
 	"fmt"
 
-	"github.com/openrdap/rdap"
+	"github.com/projectdiscovery/rdap"
 )
 
 func Example() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/openrdap/rdap
+module github.com/projectdiscovery/rdap
 
 go 1.12
 

--- a/print_test.go
+++ b/print_test.go
@@ -7,7 +7,7 @@ package rdap
 import (
 	"testing"
 
-	"github.com/openrdap/rdap/test"
+	"github.com/projectdiscovery/rdap/test"
 )
 
 func TestPrintDomain(t *testing.T) {

--- a/response.go
+++ b/response.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/openrdap/rdap/bootstrap"
+	"github.com/projectdiscovery/rdap/bootstrap"
 )
 
 type Response struct {

--- a/vcard_test.go
+++ b/vcard_test.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/openrdap/rdap/test"
+	"github.com/projectdiscovery/rdap/test"
 )
 
 func TestVCardErrors(t *testing.T) {


### PR DESCRIPTION
## Description
This PR implements the following:
- Update import paths to the current fork
- Ensure the map value exists before accessing it in `client.Lookup`